### PR TITLE
Add resilient gallery media fallbacks and fix tests setup

### DIFF
--- a/client/src/gallery/utils.ts
+++ b/client/src/gallery/utils.ts
@@ -1,0 +1,6 @@
+export function getPrimaryImageSrc(srcsets:{avif:string; webp:string; jpg:string}): string {
+  const candidate = srcsets.jpg || srcsets.webp || srcsets.avif || '';
+  if (!candidate) return '';
+  const first = candidate.split(',')[0].trim().split(' ')[0];
+  return first;
+}

--- a/client/src/pages/course-details.tsx
+++ b/client/src/pages/course-details.tsx
@@ -10,6 +10,7 @@ import { instructors } from '@/data/instructors';
 import { useLanguage } from '@/contexts/LanguageContext';
 import StructuredData from '@/components/StructuredData';
 import { fetchGallery, type GalleryItem } from '@/gallery/api';
+import { getPrimaryImageSrc } from '@/gallery/utils';
 
 type MediaItem = { src: string; type: 'image' | 'video' };
 
@@ -83,11 +84,13 @@ export default function CourseDetails() {
     staleTime: 5 * 60 * 1000, // 5 minutes
   });
 
-  const galleryMedia: MediaItem[] = galleryResponse?.items?.map((item: any) => ({
-    src: item.srcsets?.jpg?.split(' ')[2] || item.srcsets?.jpg?.split(' ')[0] || '/placeholder.jpg',
-    type: 'image' as const,
-    alt: item.alt || item.title || 'Gallery image'
-  })) || [];
+  const galleryMedia: MediaItem[] = galleryResponse?.items
+    ?.map((item: any) => ({
+      src: item.isVideo ? item.videoUrl : getPrimaryImageSrc(item.srcsets),
+      type: (item.isVideo ? 'video' : 'image') as 'image' | 'video',
+    }))
+    .filter((m: MediaItem) => !!m.src) || [];
+
   // Use gallery images as course gallery
   const courseGallery = galleryMedia.slice(0, 20).sort(() => Math.random() - 0.5);
 

--- a/client/src/pages/gallery.tsx
+++ b/client/src/pages/gallery.tsx
@@ -5,6 +5,7 @@ import { Play, Grid, List } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { fetchGallery, type GalleryItem, type GalleryResponse } from '@/gallery/api';
+import { getPrimaryImageSrc } from '@/gallery/utils';
 
 function OptimizedMediaCard({ item, index }: { item: GalleryItem; index: number }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -71,12 +72,12 @@ function OptimizedMediaCard({ item, index }: { item: GalleryItem; index: number 
           ) : (
             // Image element
             <picture>
-              <source srcSet={item.srcsets.avif} type="image/avif" />
-              <source srcSet={item.srcsets.webp} type="image/webp" />
+              {item.srcsets.avif && <source srcSet={item.srcsets.avif} type="image/avif" />}
+              {item.srcsets.webp && <source srcSet={item.srcsets.webp} type="image/webp" />}
               <img
                 ref={mediaRef}
-                src={item.srcsets.jpg.split(' ')[0]}
-                srcSet={item.srcsets.jpg}
+                src={getPrimaryImageSrc(item.srcsets)}
+                srcSet={item.srcsets.jpg || item.srcsets.webp || item.srcsets.avif}
                 alt={item.alt || item.title}
                 className={`w-full h-auto object-cover transition-all duration-300 group-hover:scale-105 ${
                   loaded ? 'opacity-100' : 'opacity-0'

--- a/client/src/pages/students-gallery.tsx
+++ b/client/src/pages/students-gallery.tsx
@@ -5,6 +5,7 @@ import { Play, Grid3X3, LayoutGrid } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { fetchGallery, type GalleryItem, type GalleryResponse } from '@/gallery/api';
+import { getPrimaryImageSrc } from '@/gallery/utils';
 
 function OptimizedMediaCard({ item, index }: { item: GalleryItem; index: number }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -73,8 +74,8 @@ function OptimizedMediaCard({ item, index }: { item: GalleryItem; index: number 
               {item.srcsets.webp && <source srcSet={item.srcsets.webp} type="image/webp" />}
               <img
                 ref={mediaRef}
-                src={item.srcsets.jpg.split(' ')[0]}
-                srcSet={item.srcsets.jpg}
+                src={getPrimaryImageSrc(item.srcsets)}
+                srcSet={item.srcsets.jpg || item.srcsets.webp || item.srcsets.avif}
                 alt={item.alt || item.title}
                 className={`w-full h-auto object-cover transition-all duration-300 group-hover:scale-105 ${
                   loaded ? 'opacity-100' : 'opacity-0'
@@ -146,6 +147,20 @@ export default function StudentsGalleryPage() {
     displayMediaLength: displayMedia.length,
     firstItemSrcsets: displayMedia[0]?.srcsets
   });
+
+  if (error) {
+    console.error('Students gallery fetch error:', error);
+    return (
+      <main className="pt-36 pb-20 bg-deep-black text-white">
+        <section className="text-center mb-20 px-4">
+          <h1 className="font-serif text-5xl font-bold mb-4">
+            {t('page.students.title')} <span className="premium-accent">{t('page.students.title.highlight')}</span>
+          </h1>
+          <p className="text-gray-300 max-w-2xl mx-auto">Unable to load gallery images. Please try again later.</p>
+        </section>
+      </main>
+    );
+  }
 
   const getGridClasses = () => {
     const base = isMobile ? 'grid-cols-2' : 'grid-cols-3 lg:grid-cols-4';

--- a/client/src/pages/success-gallery.tsx
+++ b/client/src/pages/success-gallery.tsx
@@ -5,6 +5,7 @@ import { Play } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { fetchGallery, type GalleryItem } from '@/gallery/api';
+import { getPrimaryImageSrc } from '@/gallery/utils';
 
 function OptimizedMediaCard({ item, index }: { item: GalleryItem; index: number }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -70,8 +71,8 @@ function OptimizedMediaCard({ item, index }: { item: GalleryItem; index: number 
               {item.srcsets.webp && <source srcSet={item.srcsets.webp} type="image/webp" />}
               <img
                 ref={mediaRef}
-                src={item.srcsets.jpg.split(' ')[0]}
-                srcSet={item.srcsets.jpg}
+                src={getPrimaryImageSrc(item.srcsets)}
+                srcSet={item.srcsets.jpg || item.srcsets.webp || item.srcsets.avif}
                 alt={item.alt || item.title}
                 className={`w-full h-48 sm:h-56 md:h-64 object-cover transition-all duration-300 group-hover:scale-105 ${
                   loaded ? 'opacity-100' : 'opacity-0'
@@ -138,10 +139,24 @@ export default function SuccessGalleryPage() {
 
   // Temporary debug to verify fix
   console.log('Success Gallery Rendering:', {
-    dataLength: data.length,  
+    dataLength: data.length,
     displayMediaLength: displayMedia.length,
     firstItemSrcsets: displayMedia[0]?.srcsets
   });
+
+  if (error) {
+    console.error('Success gallery fetch error:', error);
+    return (
+      <main className="pt-36 pb-20 bg-deep-black text-white">
+        <section className="text-center mb-20 px-4">
+          <h1 className="font-serif text-5xl font-bold mb-4">
+            {t('page.success.title')} <span className="premium-accent">{t('page.success.title.highlight')}</span>
+          </h1>
+          <p className="text-gray-300 max-w-2xl mx-auto">Unable to load gallery images. Please try again later.</p>
+        </section>
+      </main>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,8 +2,9 @@ import '@testing-library/jest-dom';
 import { TextEncoder, TextDecoder } from 'util';
 
 // Mock global objects for Node.js environment
-global.TextEncoder = TextEncoder;
-global.TextDecoder = TextDecoder;
+// Cast through `any` to bypass mismatched DOM vs Node typings
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder as unknown as typeof global.TextDecoder;
 
 // Mock fetch for API tests
 global.fetch = jest.fn();


### PR DESCRIPTION
## Summary
- add helper to pick first available gallery image source
- refactor gallery, student, and success pages to use helper and show load errors
- populate course mini galleries with validated media
- cast TextEncoder/TextDecoder globals for Jest

## Testing
- `node run-tests.js` *(fails: Property 'title' does not exist on type…, SyntaxError: Unexpected token '<', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689f29f61514832e995208f118338dab